### PR TITLE
Release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Crystal
+        env:
+          HOMEBREW_NO_INSTALL_UPGRADE: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        run: brew update && brew install crystal || true
+
+      - name: Build the binary
+        run: make arm64-apple-darwin
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: liger_arm64-apple-darwin
+          path: build/liger_arm64-apple-darwin.gz
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: latest
+
+      - name: Build the binary
+        run: make x86_64-pc-windows-msvc
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: liger_x86_64-pc-windows-msvc
+          path: build/liger_x86_64-pc-windows-msvc.gz
+
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build the static binary
+        run: docker build -t liger .
+
+      - name: Copy binary to host
+        run: |
+          docker run -v $PWD:/app/host --rm liger:latest cp ./build/liger_x86_64-unknown-linux-musl.gz ./host/liger_x86_64-unknown-linux-musl.gz
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: liger_x86_64-unknown-linux-musl
+          path: ./liger_x86_64-unknown-linux-musl.gz
+
+  release:
+    name: Create Release
+    needs: [macos, windows, linux]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/liger_arm64-apple-darwin/liger_arm64-apple-darwin.gz
+            artifacts/liger_x86_64-pc-windows-msvc/liger_x86_64-pc-windows-msvc.gz
+            artifacts/liger_x86_64-unknown-linux-musl/liger_x86_64-unknown-linux-musl.gz
+          generate_release_notes: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM crystallang/crystal:1.16.1-alpine
+
+WORKDIR /app
+
+# Add build dependencies
+RUN apk add --update --no-cache --force-overwrite \
+      llvm18-dev llvm18-static g++ libxml2-static zstd-static make
+
+# Copy source
+COPY . /app/
+
+# Build liger static binary
+RUN shards build liger \
+      --no-debug --progress --stats --production --static --release \
+      --ignore-crystal-version && \
+      mkdir -p build && \
+      gzip -c bin/liger > build/liger_x86_64-unknown-linux-musl.gz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+# Liger Release Builder
+# Builds cross-platform binaries for GitHub releases
+
+VERSION := $(shell grep 'VERSION' src/liger.cr | sed 's/.*"\(.*\)".*/\1/')
+BUILD_DIR := build
+
+.PHONY: all clean help arm64-apple-darwin x86_64-pc-windows-msvc x86_64-unknown-linux-musl
+
+all: local
+
+# Detect current platform and build
+local: $(BUILD_DIR)
+	@echo "Building for current platform..."
+	shards build liger --release --no-debug --stats --progress
+	gzip -c bin/liger > $(BUILD_DIR)/liger_$$(uname -m)-$$(uname -s | tr '[:upper:]' '[:lower:]').gz
+	@echo "Built: $(BUILD_DIR)/liger_$$(uname -m)-$$(uname -s | tr '[:upper:]' '[:lower:]').gz"
+
+# macOS ARM64 (Apple Silicon)
+arm64-apple-darwin: $(BUILD_DIR)
+	@echo "Building for macOS ARM64..."
+	shards build liger --release --no-debug --stats --progress
+	gzip -c bin/liger > $(BUILD_DIR)/liger_arm64-apple-darwin.gz
+	@echo "Built: $(BUILD_DIR)/liger_arm64-apple-darwin.gz"
+
+# Windows x86_64
+x86_64-pc-windows-msvc: $(BUILD_DIR)
+	@echo "Building for Windows x86_64..."
+	shards build liger --release --no-debug --stats --progress
+	gzip -c bin/liger.exe > $(BUILD_DIR)/liger_x86_64-pc-windows-msvc.gz
+	@echo "Built: $(BUILD_DIR)/liger_x86_64-pc-windows-msvc.gz"
+
+# Linux x86_64 musl (requires Docker)
+x86_64-unknown-linux-musl: $(BUILD_DIR)
+	@echo "Building for Linux x86_64 musl..."
+	@if ! command -v docker >/dev/null 2>&1 && ! command -v podman >/dev/null 2>&1; then \
+		echo "Error: Docker or Podman required for Linux musl build"; \
+		exit 1; \
+	fi
+	docker build -t liger .
+	docker run --rm -v "$(PWD):/app/host" liger cp ./build/liger_x86_64-unknown-linux-musl.gz /app/host/build/
+	@echo "Built: $(BUILD_DIR)/liger_x86_64-unknown-linux-musl.gz"
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR) bin
+
+clean:
+	rm -rf $(BUILD_DIR) bin
+
+help:
+	@echo "Liger Release Builder"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  make local                    - Build for current platform"
+	@echo "  make arm64-apple-darwin        - Build for macOS ARM64 (Apple Silicon)"
+	@echo "  make x86_64-pc-windows-msvc    - Build for Windows x86_64"
+	@echo "  make x86_64-unknown-linux-musl - Build for Linux x86_64 (requires Docker)"
+	@echo "  make clean                     - Remove build artifacts"
+	@echo "  make help                      - Show this help"

--- a/src/crystal/semantic_analyzer.cr
+++ b/src/crystal/semantic_analyzer.cr
@@ -330,6 +330,7 @@ module Liger
           content = "```crystal\n#{output.strip}\n```"
           return LSP::Hover.new(LSP::MarkupContent.new("markdown", content))
         end
+        # ameba:disable Lint/UnusedRescueVariable
       rescue ex
         {% if flag?(:debug) %}
           STDERR.puts "Error getting hover info: #{ex.message}"

--- a/src/lsp/json_rpc.cr
+++ b/src/lsp/json_rpc.cr
@@ -123,7 +123,7 @@ module LSP
         begin
           message = read_message
           process_message(message) if message
-        rescue ex : IO::EOFError
+        rescue IO::EOFError
           STDERR.puts "Input stream closed, exiting server"
           break
         rescue ex : Exception


### PR DESCRIPTION
Adds release builds for linux, windows and mac, triggered by a github release (`v*` tag creation).

Sample run: https://github.com/ricardobeat/liger/actions/runs/24373196198?pr=1

This will allow replacing crystalline completely in the [zed-editor](https://github.com/crystal-lang-tools/zed-crystal) extension without requiring any separate user installs.