### PR TITLE
Expose text formatting

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,0 +1,2 @@
+version: 2.0
+shards: {}

--- a/src/crystal/formatter.cr
+++ b/src/crystal/formatter.cr
@@ -1,0 +1,55 @@
+module Liger
+  # Formats Crystal code using `crystal tool format`
+  class Formatter
+    # Format the given text and return the formatted result
+    def self.format(text : String) : String?
+      format_from_stdin(text)
+    end
+
+    # Format a single file and return array of text edits
+    def self.format_document(original_text : String, version : Int32? = nil)
+      formatted = format_from_stdin(original_text)
+
+      if formatted == original_text
+        return [] of LSP::TextEdit
+      end
+
+      # Replace full document
+      range = LSP::Range.new(
+        LSP::Position.new(0, 0),
+        LSP::Position.new(Int32::MAX, Int32::MAX)
+      )
+
+      [LSP::TextEdit.new(range, formatted)]
+    end
+
+    private def self.format_from_stdin(source : String) : String
+      STDERR.puts "[Formatter] Running crystal tool format on #{source.size} chars"
+
+      output = IO::Memory.new
+      error = IO::Memory.new
+
+      status = Process.run(
+        "crystal",
+        args: ["tool", "format", "-"],
+        input: IO::Memory.new(source),
+        output: output,
+        error: error,
+      )
+
+      STDERR.puts "[Formatter] Exit status: #{status}"
+      if status.success?
+        output.rewind
+        result = output.gets_to_end
+        STDERR.puts "[Formatter] Output size: #{result.size} chars"
+        STDERR.puts "[Formatter] Output preview: #{result[0..50].inspect}" unless result.empty?
+        result
+      else
+        error.rewind
+        error_msg = error.gets_to_end
+        STDERR.puts "[Formatter] Error: #{error_msg}"
+        source
+      end
+    end
+  end
+end

--- a/src/lsp/protocol.cr
+++ b/src/lsp/protocol.cr
@@ -134,6 +134,32 @@ module LSP
     end
   end
 
+  # Document formatting params
+  struct DocumentFormattingParams
+    include JSON::Serializable
+
+    @[JSON::Field(key: "textDocument")]
+    property text_document : TextDocumentIdentifier
+    property? options : FormattingOptions?
+
+    def initialize(@text_document : TextDocumentIdentifier)
+    end
+  end
+
+  # Formatting options
+  struct FormattingOptions
+    include JSON::Serializable
+
+    property? tab_size : Int32?
+    property? insert_spaces : Bool?
+    property? trim_trailing_whitespace : Bool?
+    property? insert_final_newline : Bool?
+    property? trim_final_newlines : Bool?
+
+    def initialize
+    end
+  end
+
   # Text document edit
   struct TextDocumentEdit
     include JSON::Serializable

--- a/src/lsp/server.cr
+++ b/src/lsp/server.cr
@@ -4,6 +4,7 @@ require "./json_rpc"
 require "./text_document"
 require "../crystal/parser"
 require "../crystal/semantic_analyzer"
+require "../crystal/formatter"
 
 module LSP
   # LSP server implementation
@@ -54,6 +55,7 @@ module LSP
       @rpc.on_request("workspace/symbol") { |params| handle_workspace_symbol(params) }
       @rpc.on_request("textDocument/rename") { |params| handle_rename(params) }
       @rpc.on_request("textDocument/prepareRename") { |params| handle_prepare_rename(params) }
+      @rpc.on_request("textDocument/formatting") { |params| handle_formatting(params) }
     end
 
     # Handle an initialize request
@@ -90,6 +92,7 @@ module LSP
         "renameProvider"          => {
           "prepareProvider" => true,
         },
+        "documentFormattingProvider" => true,
       }
 
       result = {
@@ -366,6 +369,26 @@ module LSP
       end
 
       JSON.parse("null")
+    end
+
+    # Formatting request
+    private def handle_formatting(params : JSON::Any?) : JSON::Any
+      return JSON.parse("null") unless params
+
+      doc_params = DocumentFormattingParams.from_json(params.to_json)
+      STDERR.puts "[LSP] Formatting request for: #{doc_params.text_document.uri}"
+
+      doc = @document_manager.get(doc_params.text_document.uri)
+      unless doc
+        STDERR.puts "[LSP] Document not found: #{doc_params.text_document.uri}"
+        return JSON.parse("null")
+      end
+
+      STDERR.puts "[LSP] Document text length: #{doc.text.size} chars"
+      edits = Liger::Formatter.format_document(doc.text)
+      STDERR.puts "[LSP] Formatting returned #{edits.size} edits"
+
+      JSON.parse(edits.to_json)
     end
 
     # Send diagnostics for a document


### PR DESCRIPTION
This PR exposes formatting via `textDocument/formatting`, by spawning `crystal tool format`. 

Why? Mostly to improve first time user experience; if we enable `liger` as the default LSP in `zed-crystal`, installing the extension will automatically enable formatting. The LSP-provided formatting is a little slower than the external one but very usable, and can be easily replaced with the standard external formatter config:

```json
languages: {
  "Crystal": {
      "formatter": {
        "external": {
          "command": "crystal",
          "arguments": ["tool", "format", "-"],
        },
      },
    },
}
```

As far as I can see, Zed doesn't allow extensions to define external formatters, which would be ideal.